### PR TITLE
Remove notnull contraint from username

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -23,7 +23,6 @@
 			<field>
 				<name>username</name>
 				<type>text</type>
-				<notnull>true</notnull>
 			</field>
 			<field>
 				<name>password</name>


### PR DESCRIPTION
It is not required since we can have an registration entry without a username
in the database, either from migration or when signing up with email first
in the web interface

Fixes #92 