### PR TITLE
New Feature: Optionally require an admin to approve the registration − new implementation

### DIFF
--- a/controller/registercontroller.php
+++ b/controller/registercontroller.php
@@ -157,7 +157,7 @@ class RegisterController extends Controller {
 			return new TemplateResponse(
 				'registration',
 				'message',
-				array('msg' => "Your account has been successfully created, but it still needs approval from an administrator."),
+				array('msg' => $this->l10n->t("Your account has been successfully created, but it still needs approval from an administrator.")),
 				'guest');
 		}
 	}

--- a/controller/registercontroller.php
+++ b/controller/registercontroller.php
@@ -149,7 +149,17 @@ class RegisterController extends Controller {
 				], 'guest');
 		}
 
-		return $this->registrationService->loginUser($user->getUID(), $username, $password, false);
+		if ($user->isEnabled()) {
+			// log the user
+			return $this->registrationService->loginUser($user->getUID(), $username, $password, false);
+		} else {
+			// warn the user their account needs admin validation
+			return new TemplateResponse(
+				'registration',
+				'message',
+				array('msg' => "Your account has been successfully created, but it still needs approval from an administrator."),
+				'guest');
+		}
 	}
 
 	private function renderError($error, $hint="") {

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -47,14 +47,21 @@ class SettingsController extends Controller {
 	 *
 	 * @param string $registered_user_group all newly registered user will be put in this group
 	 * @param string $allowed_domains Registrations are only allowed for E-Mailadresses with these domains
+     * @param bool $admin_approval_required newly registered users have to be validated by an admin
 	 * @return DataResponse
 	 */
-	public function admin($registered_user_group, $allowed_domains) {
+	public function admin($registered_user_group, $allowed_domains, $admin_approval_required) {
+		// handle domains
 		if ( ( $allowed_domains==='' ) || ( $allowed_domains === NULL ) ){
 			$this->config->deleteAppValue($this->appName, 'allowed_domains');
 		}else{
 			$this->config->setAppValue($this->appName, 'allowed_domains', $allowed_domains);
 		}
+
+		// handle admin validation
+		$this->config->setAppValue($this->appName, 'admin_approval_required', $admin_approval_required ? "yes" : "no");
+
+		// handle groups
 		$groups = $this->groupmanager->search('');
 		$group_id_list = array();
 		foreach ( $groups as $group ) {
@@ -92,17 +99,25 @@ class SettingsController extends Controller {
 	 * @return TemplateResponse
 	 */
 	public function displayPanel() {
+		// handle groups
 		$groups = $this->groupmanager->search('');
 		$group_id_list = [];
 		foreach ( $groups as $group ) {
 			$group_id_list[] = $group->getGid();
 		}
 		$current_value = $this->config->getAppValue($this->appName, 'registered_user_group', 'none');
+
+		// handle domains
 		$allowed_domains = $this->config->getAppValue($this->appName, 'allowed_domains', '');
+
+		// handle admin validation
+		$admin_approval_required = $this->config->getAppValue($this->appName, 'admin_approval_required', "no");
+
 		return new TemplateResponse('registration', 'admin', [
 			'groups' => $group_id_list,
 			'current' => $current_value,
-			'allowed' => $allowed_domains
+			'allowed' => $allowed_domains,
+			'approval_required' => $admin_approval_required
 		], '');
 	}
 }

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -38,6 +38,9 @@ OC.L10N.register(
     "Email" : "E-Mail",
     "Request verification link" : "Bestätigungslink anfragen",
     "Please re-enter a valid email address" : "Bitte nochmals eine gültige E-Mail-Adresse angeben",
-    "You will receive an email with a verification link" : "Du wirst eine E-Mail mit einem Bestätigungslink erhalten"
+    "You will receive an email with a verification link" : "Du wirst eine E-Mail mit einem Bestätigungslink erhalten",
+    "A new user \"%s\" has created an account on %s and awaits admin approbation" : "Ein neuer Benutzer \"%s\" hat ein Konto auf %s erstellt und erwarte den Administrator Approbation ",
+    "Your account has been successfully created, but it still needs approval from an administrator." : "Ihr Konto wurde erfolgreich erstellt, aber es muss von einem Administrator genehmigt werden.",
+    "Require admin approval?" : "Ist der Administrator Approbation erforderlich?"
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -36,6 +36,9 @@
     "Email" : "E-Mail",
     "Request verification link" : "Bestätigungslink anfragen",
     "Please re-enter a valid email address" : "Bitte nochmals eine gültige E-Mail-Adresse angeben",
-    "You will receive an email with a verification link" : "Du wirst eine E-Mail mit einem Bestätigungslink erhalten"
+    "You will receive an email with a verification link" : "Du wirst eine E-Mail mit einem Bestätigungslink erhalten",
+    "A new user \"%s\" has created an account on %s and awaits admin approbation" : "Ein neuer Benutzer \"%s\" hat ein Konto auf %s erstellt und erwarte den Administrator Approbation ",
+    "Your account has been successfully created, but it still needs approval from an administrator." : "Ihr Konto wurde erfolgreich erstellt, aber es muss von einem Administrator genehmigt werden.",
+    "Require admin approval?" : "Ist der Administrator Approbation erforderlich?"
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -30,6 +30,9 @@ OC.L10N.register(
     "Email" : "Adresse courriel",
     "Request verification link" : "Demander un lien de vérification.",
     "Please re-enter a valid email address" : "Veuillez indiquer une adresse courriel valide",
-    "You will receive an email with a verification link" : "Vous allez recevoir un courriel avec un lien de vérification"
+    "You will receive an email with a verification link" : "Vous allez recevoir un courriel avec un lien de vérification",
+    "A new user \"%s\" has created an account on %s and awaits admin approbation" : "Un nouvel utilisateur \"%s\" a créé un compte sur %s et attend l'approbation d'un administrateur",
+    "Your account has been successfully created, but it still needs approval from an administrator." : "Votre compte a bien été créé, il doit maintenant être approuvé par un administrateur.",
+    "Require admin approval?" : "Nécessite l'approbation d'un administrateur ?"
 },
 "nplurals=2; plural=(n > 1);");

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -28,6 +28,9 @@
     "Email" : "Adresse courriel",
     "Request verification link" : "Demander un lien de vérification.",
     "Please re-enter a valid email address" : "Veuillez indiquer une adresse courriel valide",
-    "You will receive an email with a verification link" : "Vous allez recevoir un courriel avec un lien de vérification"
+    "You will receive an email with a verification link" : "Vous allez recevoir un courriel avec un lien de vérification",
+    "A new user \"%s\" has created an account on %s and awaits admin approbation" : "Un nouvel utilisateur \"%s\" a créé un compte sur %s et attend l'approbation d'un administrateur",
+    "Your account has been successfully created, but it still needs approval from an administrator." : "Votre compte a bien été créé, il doit maintenant être approuvé par un administrateur.",
+    "Require admin approval?" : "Nécessite l'approbation d'un administrateur ?"
 },"pluralForm" :"nplurals=2; plural=(n > 1);"
 }

--- a/l10n/ja.js
+++ b/l10n/ja.js
@@ -30,6 +30,9 @@ OC.L10N.register(
     "Email" : "メール",
     "Request verification link" : "確認URLリンクをリクエスト",
     "Please re-enter a valid email address" : "有効なメールアドレスを再度入力してください。",
-    "You will receive an email with a verification link" : "確認URLの入ったメールをお送り致します。"
+    "You will receive an email with a verification link" : "確認URLの入ったメールをお送り致します。",
+    "A new user \"%s\" has created an account on %s and awaits admin approbation" : "新しいユーザー \"%s\" を アカウント名 \"%s\" として作成しました、今管理者の承認は必要です",
+    "Your account has been successfully created, but it still needs approval from an administrator." : "アカウントは作成成功しましたけど、管理者の承認は必要です。",
+    "Require admin approval?" : "管理者の承認は必要ですか"
 },
 "nplurals=1; plural=0;");

--- a/l10n/ja.json
+++ b/l10n/ja.json
@@ -28,6 +28,9 @@
     "Email" : "メール",
     "Request verification link" : "確認URLリンクをリクエスト",
     "Please re-enter a valid email address" : "有効なメールアドレスを再度入力してください。",
-    "You will receive an email with a verification link" : "確認URLの入ったメールをお送り致します。"
+    "You will receive an email with a verification link" : "確認URLの入ったメールをお送り致します。",
+    "A new user \"%s\" has created an account on %s and awaits admin approbation" : "新しいユーザー \"%s\" を アカウント名 \"%s\" として作成しました、今管理者の承認は必要です",
+    "Your account has been successfully created, but it still needs approval from an administrator." : "アカウントは作成成功しましたけど、管理者の承認は必要です。",
+    "Require admin approval?" : "管理者の承認は必要ですか"
 },"pluralForm" :"nplurals=1; plural=0;"
 }

--- a/service/mailservice.php
+++ b/service/mailservice.php
@@ -106,11 +106,25 @@ class MailService {
 
 	/**
 	 * @param string $userId
+	 * @param string $userGroupId
 	 * @param bool $userIsEnabled
 	 */
-	public function notifyAdmins($userId, $userIsEnabled) {
+	public function notifyAdmins($userId, $userIsEnabled, $userGroupId) {
 		// Notify admin
 		$admin_users = $this->groupManager->get('admin')->getUsers();
+
+		// if the user is disabled and belongs to a group
+		// add subadmins of this group to notification list
+		if (!$userIsEnabled and $userGroupId) {
+			$group = $this->groupManager->get($userGroupId);
+			$subadmin_users = $group->getSubAdmin()->getGroupsSubAdmins($group);
+			foreach ($subadmin_users as $user) {
+				if (!in_array($user, $admin_users)) {
+					$admin_users[] = $user;
+				}
+			}
+		}
+
 		$to_arr = array();
 		foreach ( $admin_users as $au ) {
 			$au_email = $au->getEMailAddress();

--- a/service/mailservice.php
+++ b/service/mailservice.php
@@ -135,9 +135,9 @@ class MailService {
 			'user' => $username,
 			'sitename' => $this->defaults->getName()
 		];
-		$html_template = new TemplateResponse('registration', 'email.newuser_html', $template_var, 'blank');
+		$html_template = new TemplateResponse('registration', 'email.newuser.disabled_html', $template_var, 'blank');
 		$html_part = $html_template->render();
-		$plaintext_template = new TemplateResponse('registration', 'email.newuser_plaintext', $template_var, 'blank');
+		$plaintext_template = new TemplateResponse('registration', 'email.newuser.disabled_plaintext', $template_var, 'blank');
 		$plaintext_part = $plaintext_template->render();
 		$subject = $this->l10n->t('A new user "%s" has created an account on %s', [$username, $this->defaults->getName()]);
 

--- a/service/mailservice.php
+++ b/service/mailservice.php
@@ -117,7 +117,7 @@ class MailService {
 		// add subadmins of this group to notification list
 		if (!$userIsEnabled and $userGroupId) {
 			$group = $this->groupManager->get($userGroupId);
-			$subadmin_users = $this->$groupManager->getSubAdmin()->getGroupsSubAdmins($group);
+			$subadmin_users = $this->groupManager->getSubAdmin()->getGroupsSubAdmins($group);
 			foreach ($subadmin_users as $user) {
 				if (!in_array($user, $admin_users)) {
 					$admin_users[] = $user;

--- a/service/mailservice.php
+++ b/service/mailservice.php
@@ -117,7 +117,7 @@ class MailService {
 		// add subadmins of this group to notification list
 		if (!$userIsEnabled and $userGroupId) {
 			$group = $this->groupManager->get($userGroupId);
-			$subadmin_users = $group->getSubAdmin()->getGroupsSubAdmins($group);
+			$subadmin_users = $this->$groupManager->getSubAdmin()->getGroupsSubAdmins($group);
 			foreach ($subadmin_users as $user) {
 				if (!in_array($user, $admin_users)) {
 					$admin_users[] = $user;

--- a/service/registrationservice.php
+++ b/service/registrationservice.php
@@ -288,9 +288,12 @@ class RegistrationService {
 			try {
 				$group = $this->groupManager->get($registered_user_group);
 				$group->addUser($user);
+				$groupId = $group->gitGID();
 			} catch (\Exception $e) {
 				throw new RegistrationException($e->getMessage());
 			}
+		} else {
+			$groupId = "";
 		}
 
 		// disable user if this is requested by config
@@ -307,7 +310,7 @@ class RegistrationService {
 			}
 		}
 
-		$this->mailService->notifyAdmins($userId, $user->isEnabled());
+		$this->mailService->notifyAdmins($userId, $user->isEnabled(), $groupId);
 		return $user;
 	}
 

--- a/service/registrationservice.php
+++ b/service/registrationservice.php
@@ -288,7 +288,7 @@ class RegistrationService {
 			try {
 				$group = $this->groupManager->get($registered_user_group);
 				$group->addUser($user);
-				$groupId = $group->gitGID();
+				$groupId = $group->getGID();
 			} catch (\Exception $e) {
 				throw new RegistrationException($e->getMessage());
 			}

--- a/service/registrationservice.php
+++ b/service/registrationservice.php
@@ -293,6 +293,9 @@ class RegistrationService {
 			}
 		}
 
+		// Disable user unconditionaly
+		$user->setEnabled(false);
+
 		// Delete pending registration if no client secret is stored
 		if($registration->getClientSecret() === null) {
 			$res = $this->registrationMapper->delete($registration);

--- a/service/registrationservice.php
+++ b/service/registrationservice.php
@@ -293,8 +293,11 @@ class RegistrationService {
 			}
 		}
 
-		// Disable user unconditionaly
-		$user->setEnabled(false);
+		// disable user if this is requested by config
+		$admin_approval_required = $this->config->getAppValue($this->appName, 'admin_approval_required', "no");
+		if ($admin_approval_required) {
+			$user->setEnabled(false);
+		}
 
 		// Delete pending registration if no client secret is stored
 		if($registration->getClientSecret() === null) {
@@ -304,7 +307,7 @@ class RegistrationService {
 			}
 		}
 
-		$this->mailService->notifyAdmins($userId);
+		$this->mailService->notifyAdmins($userId, $user->isEnabled());
 		return $user;
 	}
 

--- a/service/registrationservice.php
+++ b/service/registrationservice.php
@@ -295,7 +295,7 @@ class RegistrationService {
 
 		// disable user if this is requested by config
 		$admin_approval_required = $this->config->getAppValue($this->appName, 'admin_approval_required', "no");
-		if ($admin_approval_required) {
+		if ($admin_approval_required == "yes") {
 			$user->setEnabled(false);
 		}
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -23,4 +23,9 @@ foreach ( $_['groups'] as $group ) {
 	<em><?php p($l->t('Enter a semicolon-separated list of allowed domains. Example: owncloud.com;github.com'));?></em>
 	</p>
 
+	<p>
+	<label for="admin_approval_required"><?php p($l->t('Require admin approval?')); ?>
+	<input type="checkbox" id="admin_approval_required" name="admin_approval_required" <?php if($_['approval_required'] == "yes" ) echo " checked"; ?>>
+	</label>
+	</p>
 </form>

--- a/templates/email.newuser.disabled_html.php
+++ b/templates/email.newuser.disabled_html.php
@@ -1,0 +1,2 @@
+<?php
+echo $l->t('A new user "%s" has created an account on %s and awaits admin validation', [$_['user'], $_['sitename']]);

--- a/templates/email.newuser.disabled_html.php
+++ b/templates/email.newuser.disabled_html.php
@@ -1,2 +1,2 @@
 <?php
-echo $l->t('A new user "%s" has created an account on %s and awaits admin validation', [$_['user'], $_['sitename']]);
+echo $l->t('A new user "%s" has created an account on %s and awaits admin approbation', [$_['user'], $_['sitename']]);

--- a/templates/email.newuser.disabled_plaintext.php
+++ b/templates/email.newuser.disabled_plaintext.php
@@ -1,0 +1,2 @@
+<?php
+echo $l->t('A new user "%s" has created an account on %s and awaits admin validation', [$_['user'], $_['sitename']]);

--- a/templates/email.newuser.disabled_plaintext.php
+++ b/templates/email.newuser.disabled_plaintext.php
@@ -1,2 +1,2 @@
 <?php
-echo $l->t('A new user "%s" has created an account on %s and awaits admin validation', [$_['user'], $_['sitename']]);
+echo $l->t('A new user "%s" has created an account on %s and awaits admin approbation', [$_['user'], $_['sitename']]);


### PR DESCRIPTION
Hello registration app team

This PR is basically a re-implementation of #82 which fits within the current code base. It adds an option in the admin panel to make all newly created accounts disabled, and let admins enabled them manually. Admins and sub-admins of the default group are notified to approve the new accunts

Partial localization support is included (FR, DE, JA).

I have tested the code on my server (Nextcloud 13) and it works as expected.

The PR is massively inspired from @theCalcaholic's initial PR, most credit to them.

I don't know if the `admin-approval` branch is still active. This can be a workaround until it's finalized.