### PR TITLE
Sending admin notification email fail when one of admin users have no email set

### DIFF
--- a/service/mailservice.php
+++ b/service/mailservice.php
@@ -128,7 +128,7 @@ class MailService {
 		$to_arr = array();
 		foreach ( $admin_users as $au ) {
 			$au_email = $au->getEMailAddress();
-			if ( $au_email !== '' && $au->isEnabled()) {
+			if ( $au_email && $au->isEnabled()) {
 				$to_arr[$au_email] = $au->getDisplayName();
 			}
 		}


### PR DESCRIPTION
When one of the users of admin group have no email set the notification email is not sent because of this error:
`Sending admin notification email failed : Address in mailbox given [] does not comply with RFC 2822, 3.6.2.`