### PR TITLE
Add link to users settings page in admin notification email

### DIFF
--- a/service/mailservice.php
+++ b/service/mailservice.php
@@ -147,9 +147,12 @@ class MailService {
 	 * @throws \Exception
 	 */
 	private function sendNewUserNotifEmail(array $to, $username, $userIsEnabled) {
+		$link = $this->urlGenerator->linkToRoute('settings_users');
+		$link = $this->urlGenerator->getAbsoluteURL($link);
 		$template_var = [
 			'user' => $username,
-			'sitename' => $this->defaults->getName()
+			'sitename' => $this->defaults->getName(),
+			'link' => $link,
 		];
 
 		// handle user enableness

--- a/templates/email.newuser.disabled_html.php
+++ b/templates/email.newuser.disabled_html.php
@@ -1,2 +1,3 @@
 <?php
 echo $l->t('A new user "%s" has created an account on %s and awaits admin approbation', [$_['user'], $_['sitename']]);
+echo str_replace('{link}', $_['link'], '<br/><br/><a href="{link}">{link}</a>');

--- a/templates/email.newuser.disabled_plaintext.php
+++ b/templates/email.newuser.disabled_plaintext.php
@@ -1,2 +1,3 @@
 <?php
 echo $l->t('A new user "%s" has created an account on %s and awaits admin approbation', [$_['user'], $_['sitename']]);
+echo "\n\n".$_['link'];


### PR DESCRIPTION
This PR aims to add a simple way for an admin or a group admin to go to the right page to enable a new user, as requested by #138. A link to the users management page is added to the notification email they receive.

I know the issue requests another way of notification than simple email, but this is a quick fix. I cannot furnish a link to the disabled users tab specifically, as the navigation between tabs is not handled by URL.

Not sure if (and how) I should add a test for this.