### PR TITLE
Update registrationservice.php

### DIFF
--- a/service/registrationservice.php
+++ b/service/registrationservice.php
@@ -431,7 +431,7 @@ class RegistrationService {
 		}
 		// Render message in case redirect failed
 		return new TemplateResponse('registration', 'message',
-			['msg' => $this->l10n->t('Your account has been successfully created, you can <a href="%s">log in now</a>.'), [$this->urlGenerator->getAbsoluteURL('/')]]
+			['msg' => $this->l10n->t('Your account has been successfully created, you can <a href="%s">log in now</a>.', [$this->urlGenerator->getAbsoluteURL('/')])]
 			, 'guest'
 		);
 


### PR DESCRIPTION
[$this->urlGenerator->getAbsoluteURL('/')] should be Parameter for $this->l10n->t not for the TemplateResponse constructor.
fixing Internal Server Error on finished registration.